### PR TITLE
Add support for UpdateQuota and MigrationHierarchy to only work in the same secondary root hierarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -59,11 +59,12 @@ const (
 )
 
 // IsRq offsets
+// Secondary Roots
 const (
-	SelfOffset    = 0
-	SiblingOffset = 0
-	ParentOffset  = -1
-	ChildOffset   = 1
+	SelfOffset      = 0
+	ParentOffset    = -1
+	ChildOffset     = 1
+	NoSecondaryRoot = 1
 )
 
 var (

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: quay.io/danateamorg/hns-manual
+  newTag: v0.13

--- a/internals/utils/helper.go
+++ b/internals/utils/helper.go
@@ -34,7 +34,7 @@ func IsChildlessNamespace(namespace *ObjectContext) bool {
 // IsRq returns true if the depth of the subnamespace is less or equal
 // the pre-set rqDepth AND if the subnamespace is not a ResourcePool
 func IsRq(sns *ObjectContext, offset int) (bool, error) {
-	rootRQDepth, err := GetRqDepth(sns)
+	rootRQDepth, err := GetRqDepthFromSNS(sns)
 	if err != nil {
 		return false, err
 	}
@@ -73,13 +73,21 @@ func GetSnsDepth(sns *ObjectContext) (string, error) {
 	return strconv.Itoa(depthInt), nil
 }
 
-func GetRqDepth(sns *ObjectContext) (string, error) {
+func GetRqDepthFromSNS(sns *ObjectContext) (string, error) {
 	rootns := corev1.Namespace{}
 	parentns := corev1.Namespace{}
 	if err := sns.Client.Get(sns.Ctx, types.NamespacedName{Name: sns.Object.GetNamespace()}, &parentns); err != nil {
 		return "", err
 	}
 	if err := sns.Client.Get(sns.Ctx, types.NamespacedName{Name: parentns.Annotations[danav1.RootCrqSelector]}, &rootns); err != nil {
+		return "", err
+	}
+	return rootns.Annotations[danav1.RqDepth], nil
+}
+
+func GetRqDepthFromNS(ns *ObjectContext) (string, error) {
+	rootns := corev1.Namespace{}
+	if err := ns.Client.Get(ns.Ctx, types.NamespacedName{Name: ns.Object.GetAnnotations()[danav1.RootCrqSelector]}, &rootns); err != nil {
 		return "", err
 	}
 	return rootns.Annotations[danav1.RqDepth], nil

--- a/internals/utils/subnsHelper.go
+++ b/internals/utils/subnsHelper.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -95,4 +96,31 @@ func GetSnsListUp(ns *ObjectContext, rootns string, rclient client.Client, logge
 	}
 
 	return snsList, nil
+}
+
+// GetNSDisplayNameArray returns an array of strings that contains the hierarchy
+// of a namespace in accordance to its display-name
+func GetNSDisplayNameArray(ns *ObjectContext) []string {
+	displayName := ns.Object.GetAnnotations()["openshift.io/display-name"]
+	nsArr := strings.Split(displayName, "/")
+
+	return nsArr
+}
+
+// GetAncestor finds the nearest joint namespace of two subnamespaces in a hierarchy
+func GetAncestor(sourceArr []string, destArr []string) (string, bool, error) {
+	for i := len(sourceArr) - 1; i >= 0; i-- {
+		for j := len(destArr) - 1; j >= 0; j-- {
+			if sourceArr[i] == destArr[j] {
+				// if we've reached the end of the loop, then the Ancestor is
+				// the root namespace, and we return true - otherwise return false
+				if (i == 0) && (j == 0) {
+					return sourceArr[i], true, nil
+				} else {
+					return sourceArr[i], false, nil
+				}
+			}
+		}
+	}
+	return "", false, fmt.Errorf("root namespace does not exist")
 }

--- a/internals/webhooks/webhooks_messages.go
+++ b/internals/webhooks/webhooks_messages.go
@@ -16,7 +16,7 @@ const (
 	denyMessageUpdateResourcePoolDescendant         = "it's forbidden to change to ResourcePool when one of your descendants is ResourcePool"
 	namespaceExistsMessage                          = "a namespace of this name already exists, try to change the name"
 	denyMessageCreatingMoreThanLimit                = "it's forbidden to creating more than %v namespaces under hierarchy "
-	denyMessageMigrationNotAllowed                  = "it's forbidden to migrate in this hierarchy "
+	denyMessageMigrationNotAllowed                  = "it's forbidden to migrate from or to this level of the hierarchy"
 	denyMessageMigrationNotAllowedResourcePool      = "it's forbidden to migrate from or to a ResourcePool"
 	denyMessageMigrationNotAllowedTooFewResources   = "it's forbidden to migrate because there are not enough resources in the requested new parent"
 	denyMessageMigrationNotAllowedTooFewResourcesRP = "it's forbidden to migrate because there are not enough free resources in the ResourcePool"


### PR DESCRIPTION
Fixes issue #5, with this change, UpdateQuota and MigrationHierarchy now checks if the toNS and fromNS are from the same secondary root hierarchy and only approves if they are; otherwise it's denied

Signed-off-by: mzeevi <meytar80@gmail.com>