### PR TITLE
Modified updatequota permissions model

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/danateamorg/hns-manual
-  newTag: v0.13
+  newTag: v0.14

--- a/internals/utils/helper.go
+++ b/internals/utils/helper.go
@@ -174,3 +174,12 @@ func IndexOf(element string, arr []string) (int, error) {
 	}
 	return -1, fmt.Errorf("dont find root ns")
 }
+
+func ContainsString(sslice []string, s string) bool {
+	for _, a := range sslice {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #20. With this PR it is now possible to move resources from one namespace to another as long as you have permissions on the the namespace from which you move resources and the namespace to which you move resources is on the same branch.

Signed-off-by: mzeevi <meytar80@gmail.com>