### PR TITLE
secondary root check changed

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -21,11 +21,11 @@ const (
 )
 
 const (
-	Root   string = "root"
-	NoRole string = "none"
-	Leaf   string = "leaf"
-	True   string = "True"
-	False  string = "False"
+	Root   			string = "root"
+	NoRole 			string = "none"
+	Leaf   			string = "leaf"
+	True   			string = "True"
+	False  			string = "False"
 )
 
 // MetaGroup
@@ -50,6 +50,7 @@ const (
 	DisplayName     = "openshift.io/display-name"
 	RqDepth         = MetaGroup + "rq-depth"
 	IsRq            = MetaGroup + "is-rq"
+	IsSecondaryRoot = MetaGroup + "is-secondary-root"
 )
 
 // Finalizers
@@ -64,7 +65,6 @@ const (
 	SelfOffset      = 0
 	ParentOffset    = -1
 	ChildOffset     = 1
-	NoSecondaryRoot = 1
 )
 
 var (

--- a/internals/controllers/updatequota_controller.go
+++ b/internals/controllers/updatequota_controller.go
@@ -72,7 +72,7 @@ func (r *UpdateQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				if err != nil {
 					updatingObject.UpdateObject(func(object client.Object, log logr.Logger) (client.Object, logr.Logger) {
 						object.(*danav1.Updatequota).Status.Phase = danav1.Error
-						object.(*danav1.Updatequota).Status.Reason = "Updating the quota down the hierarchy failed at namespace" + snslistdown[i].GetName() + "\n" + err.Error()
+						object.(*danav1.Updatequota).Status.Reason = "Updating the quota down the hierarchy failed at namespace " + snslistdown[i].GetName() + "\n" + err.Error()
 						log = log.WithValues("phase", danav1.Error)
 						return object, log
 					})
@@ -90,7 +90,7 @@ func (r *UpdateQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				if err != nil {
 					updatingObject.UpdateObject(func(object client.Object, log logr.Logger) (client.Object, logr.Logger) {
 						object.(*danav1.Updatequota).Status.Phase = danav1.Error
-						object.(*danav1.Updatequota).Status.Reason = "Updating the quota up the hierarchy failed at namespace" + snslistup[i].GetName() + "\n" + err.Error()
+						object.(*danav1.Updatequota).Status.Reason = "Updating the quota up the hierarchy failed at namespace " + snslistup[i].GetName() + "\n" + err.Error()
 						log = log.WithValues("phase", danav1.Error)
 						return object, log
 					})
@@ -108,7 +108,7 @@ func (r *UpdateQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				if err != nil {
 					updatingObject.UpdateObject(func(object client.Object, log logr.Logger) (client.Object, logr.Logger) {
 						object.(*danav1.Updatequota).Status.Phase = danav1.Error
-						object.(*danav1.Updatequota).Status.Reason = "Updating the quota up the hierarchy failed at namespace" + snslistup[i].GetName() + "\n" + err.Error()
+						object.(*danav1.Updatequota).Status.Reason = "Updating the quota up the hierarchy failed at namespace " + snslistup[i].GetName() + "\n" + err.Error()
 						log = log.WithValues("phase", danav1.Error)
 						return object, log
 					})
@@ -125,7 +125,7 @@ func (r *UpdateQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				if err != nil {
 					updatingObject.UpdateObject(func(object client.Object, log logr.Logger) (client.Object, logr.Logger) {
 						object.(*danav1.Updatequota).Status.Phase = danav1.Error
-						object.(*danav1.Updatequota).Status.Reason = "Updating the quota down the hierarchy failed at namespace" + snslistdown[i].GetName() + "\n" + err.Error()
+						object.(*danav1.Updatequota).Status.Reason = "Updating the quota down the hierarchy failed at namespace " + snslistdown[i].GetName() + "\n" + err.Error()
 						log = log.WithValues("phase", danav1.Error)
 						return object, log
 					})
@@ -165,7 +165,7 @@ func (r *UpdateQuotaReconciler) getAncestor(sourcens *utils.ObjectContext, destn
 		}
 	}
 
-	return "", fmt.Errorf("dont find root ns")
+	return "", fmt.Errorf("did not find root ns")
 }
 
 func (r *UpdateQuotaReconciler) getSnsListDown(ns *utils.ObjectContext, rootns string) ([]*utils.ObjectContext, error) {

--- a/internals/utils/nsHelper.go
+++ b/internals/utils/nsHelper.go
@@ -123,3 +123,10 @@ func GetNamespaceParent(namespace client.Object) string {
 	}
 	return namespace.(*corev1.Namespace).Labels[danav1.Parent]
 }
+
+func IsSecondaryRootNamespace(namespace client.Object) bool {
+	if !isNamespace(namespace) {
+		return false
+	}
+	return namespace.(*corev1.Namespace).Annotations[danav1.IsSecondaryRoot] == danav1.True
+}

--- a/internals/webhooks/subnamespace_webhook.go
+++ b/internals/webhooks/subnamespace_webhook.go
@@ -312,7 +312,7 @@ func ValidateUpdateSnsRequest(parentQuotaObj *utils.ObjectContext, newSns *utils
 		vParent.Sub(vRequest)
 		vParent.Add(vOld)
 		if vParent.Value() < 0 {
-			return errors.New(denyMessageValidateQuotaObj + res.String() + " in subnamespace" + string(newSns.Object.GetNamespace()))
+			return errors.New(denyMessageValidateQuotaObj + res.String() + " in subnamespace: " + string(newSns.Object.GetNamespace()))
 		}
 		vRequest.Sub(vUsed)
 		if vRequest.Value() < 0 {


### PR DESCRIPTION
With this commit, secondary roots now have an annotation and a check in the updatequota and migrationhierarchy is only made when there is an annotation on the namespace

Signed-off-by: mzeevi <meytar80@gmail.com>