### PR TITLE
Subnamespace to ResourcePool conversion bug fix & upper-rp annotation addition

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -1,11 +1,10 @@
 package v1
 
 import (
-	"os"
-	"strconv"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"os"
+	"strconv"
 )
 
 type Phase string
@@ -50,6 +49,8 @@ const (
 	DisplayName     = "openshift.io/display-name"
 	RqDepth         = MetaGroup + "rq-depth"
 	IsRq            = MetaGroup + "is-rq"
+	IsUpperRp       = MetaGroup + "is-upper-rp"
+	UpperRp         = MetaGroup + "upper-rp"
 )
 
 // Finalizers

--- a/internals/controllers/subnamespace_controller.go
+++ b/internals/controllers/subnamespace_controller.go
@@ -141,6 +141,7 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		return ctrl.Result{}, err
 	}
 	subspaceChilds, err := utils.NewObjectContextList(subspace.Ctx, subspace.Log, subspace.Client, &danav1.SubnamespaceList{}, client.InNamespace(namespace.Object.GetName()))
+
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -223,6 +224,10 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+
+	if err := utils.AppendUpperResourcePoolAnnotation(subspace, subspaceparent); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	r.addSnsChildNamespaceEvent(subspace)

--- a/internals/utils/helper.go
+++ b/internals/utils/helper.go
@@ -31,6 +31,61 @@ func IsChildlessNamespace(namespace *ObjectContext) bool {
 	return false
 }
 
+// IsUpperResourcePool returns true if the subnamespace is an upper resource pool
+// it happens only when the parent is from subnamespace kind or is a root namespace
+func IsUpperResourcePool(sns *ObjectContext) (bool, error) {
+	isResourcePool, _ := sns.Object.GetLabels()[danav1.ResourcePool]
+	parentNs, err := NewObjectContext(sns.Ctx, sns.Log, sns.Client, types.NamespacedName{Name: sns.Object.GetNamespace()}, &corev1.Namespace{})
+	if err != nil {
+		return false, err
+	}
+	parentSns, err := NewObjectContext(sns.Ctx, sns.Log, sns.Client, types.NamespacedName{Name: parentNs.Object.GetName(), Namespace: GetNamespaceParent(parentNs.Object)}, &danav1.Subnamespace{})
+	if err != nil {
+		return false, err
+	}
+	parentRole, _ := parentNs.Object.GetAnnotations()[danav1.Role]
+	isParentResourcePool, _ := parentSns.Object.GetLabels()[danav1.ResourcePool]
+	if (isResourcePool == "true") && (parentRole == danav1.Root || isParentResourcePool == "false") {
+		return true, nil
+	}
+	return false, nil
+}
+
+// AppendUpperResourcePoolAnnotation appends annotation to determine if the subnamespace is an upper resourcepool
+// if the sns has an upper resourcepool it appends an annotation with the upper resourcepool name
+func AppendUpperResourcePoolAnnotation(sns *ObjectContext, parentSns *ObjectContext) error {
+	isUpperResourcePool, err := IsUpperResourcePool(sns)
+	if err != nil {
+		return err
+	}
+	if isUpperResourcePool {
+		if err = sns.AppendAnnotations(map[string]string{danav1.IsUpperRp: danav1.True}); err != nil {
+			return err
+		}
+	} else {
+		if err = sns.AppendAnnotations(map[string]string{danav1.IsUpperRp: danav1.False}); err != nil {
+			return err
+		}
+	}
+
+	isParentUpperResourcePool, _ := parentSns.Object.GetAnnotations()[danav1.IsUpperRp]
+	if err != nil {
+		return err
+	}
+	if isParentUpperResourcePool == danav1.True {
+		if err = sns.AppendAnnotations(map[string]string{danav1.UpperRp: parentSns.GetName()}); err != nil {
+			return err
+		}
+	}
+	upperRp, exists := parentSns.Object.GetAnnotations()[danav1.UpperRp]
+	if exists {
+		if err = sns.AppendAnnotations(map[string]string{danav1.UpperRp: upperRp}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // IsRq returns true if the depth of the subnamespace is less or equal
 // the pre-set rqDepth AND if the subnamespace is not a ResourcePool
 func IsRq(sns *ObjectContext, offset int) (bool, error) {

--- a/internals/webhooks/subnamespace_webhook.go
+++ b/internals/webhooks/subnamespace_webhook.go
@@ -161,9 +161,38 @@ func (a *SubNamespaceAnnotator) Handle(ctx context.Context, req admission.Reques
 			return admission.Allowed(allowMessageValidateQuotaObj)
 		}
 
-		if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
-			return admission.Denied(err.Error())
+		isRp, _ := sns.Object.GetLabels()[danav1.ResourcePool]
+		isUpperRp, _ := sns.Object.GetAnnotations()[danav1.IsUpperRp]
+		// if subnamespace or upper resourcepool - resources validation
+		// reduce desired resources from parent and check validity
+		if isRp != "true" || isUpperRp == danav1.True {
+			if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+				return admission.Denied(err.Error())
+			}
 		}
+
+		// Logic for resourcepool migration
+		//upperRp, exists := sns.Object.GetAnnotations()[danav1.UpperRp]
+		//if exists {
+		//	upperRpQuotaObj, err := utils.NewObjectContext(sns.Ctx, sns.Log, sns.Client, types.NamespacedName{Name: upperRp}, &qoutav1.ClusterResourceQuota{})
+		//	if err != nil {
+		//		log.Error(err, "unable to get upper resource pool quota object")
+		//		return admission.Denied(err.Error() + sns.Object.GetName())
+		//	} else {
+		//		if err := ValidateUpdateSnsRequest(upperRpQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+		//			return admission.Denied(err.Error())
+		//		}
+		//	}
+		//} else {
+		//	if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+		//		return admission.Denied(err.Error())
+		//	}
+		//}
+
+		//if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+		//	return admission.Denied(err.Error())
+		//}
+
 		if resourceName := snsChangedObject(oldSns, sns); len(resourceName) > 0 {
 			if !utils.UsernameToFilter(req.UserInfo.Username) {
 				//Write relevant log to elastic


### PR DESCRIPTION
Fixes issue #25. With this PR it is now possible to convert a Subnamespace to a ResourcePool. This change also includes `is-upper-rp` and `upper-rp` annotations addition.

Signed-off-by: liadlauber <liad6500@gmail.com>