### PR TITLE
Subnamespace to ResourcePool conversion bug fix & upper-rp annotation addition

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -1,11 +1,10 @@
 package v1
 
 import (
-	"os"
-	"strconv"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"os"
+	"strconv"
 )
 
 type Phase string
@@ -50,6 +49,9 @@ const (
 	DisplayName     = "openshift.io/display-name"
 	RqDepth         = MetaGroup + "rq-depth"
 	IsRq            = MetaGroup + "is-rq"
+	IsSecondaryRoot = MetaGroup + "is-secondary-root"
+	IsUpperRp       = MetaGroup + "is-upper-rp"
+	UpperRp         = MetaGroup + "upper-rp"
 )
 
 // Finalizers

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/danateamorg/hns-manual
-  newTag: v0.13
+  newTag: v0.14

--- a/internals/controllers/subnamespace_controller.go
+++ b/internals/controllers/subnamespace_controller.go
@@ -141,6 +141,7 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		return ctrl.Result{}, err
 	}
 	subspaceChilds, err := utils.NewObjectContextList(subspace.Ctx, subspace.Log, subspace.Client, &danav1.SubnamespaceList{}, client.InNamespace(namespace.Object.GetName()))
+
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -223,6 +224,10 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+
+	if err := utils.AppendUpperResourcePoolAnnotation(subspace, subspaceparent); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	r.addSnsChildNamespaceEvent(subspace)

--- a/internals/webhooks/subnamespace_webhook.go
+++ b/internals/webhooks/subnamespace_webhook.go
@@ -161,9 +161,38 @@ func (a *SubNamespaceAnnotator) Handle(ctx context.Context, req admission.Reques
 			return admission.Allowed(allowMessageValidateQuotaObj)
 		}
 
-		if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
-			return admission.Denied(err.Error())
+		isRp, _ := sns.Object.GetLabels()[danav1.ResourcePool]
+		isUpperRp, _ := sns.Object.GetAnnotations()[danav1.IsUpperRp]
+		// if subnamespace or upper resourcepool - resources validation
+		// reduce desired resources from parent and check validity
+		if isRp != "true" || isUpperRp == danav1.True {
+			if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+				return admission.Denied(err.Error())
+			}
 		}
+
+		// Logic for resourcepool migration
+		//upperRp, exists := sns.Object.GetAnnotations()[danav1.UpperRp]
+		//if exists {
+		//	upperRpQuotaObj, err := utils.NewObjectContext(sns.Ctx, sns.Log, sns.Client, types.NamespacedName{Name: upperRp}, &qoutav1.ClusterResourceQuota{})
+		//	if err != nil {
+		//		log.Error(err, "unable to get upper resource pool quota object")
+		//		return admission.Denied(err.Error() + sns.Object.GetName())
+		//	} else {
+		//		if err := ValidateUpdateSnsRequest(upperRpQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+		//			return admission.Denied(err.Error())
+		//		}
+		//	}
+		//} else {
+		//	if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+		//		return admission.Denied(err.Error())
+		//	}
+		//}
+
+		//if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+		//	return admission.Denied(err.Error())
+		//}
+
 		if resourceName := snsChangedObject(oldSns, sns); len(resourceName) > 0 {
 			if !utils.UsernameToFilter(req.UserInfo.Username) {
 				//Write relevant log to elastic


### PR DESCRIPTION
Fixes issue #25. With this PR it is now possible to convert a Subnamespace to a ResourcePool. This change also includes `is-upper-rp` and `upper-rp` annotations addition.

Signed-off-by: liadlauber <liad6500@gmail.com>