### PR TITLE
Subnamespace to ResourcePool conversion bug fix & upper-rp annotation addition

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -21,11 +21,11 @@ const (
 )
 
 const (
-	Root   			string = "root"
-	NoRole 			string = "none"
-	Leaf   			string = "leaf"
-	True   			string = "True"
-	False  			string = "False"
+	Root   string = "root"
+	NoRole string = "none"
+	Leaf   string = "leaf"
+	True   string = "True"
+	False  string = "False"
 )
 
 // MetaGroup
@@ -51,6 +51,8 @@ const (
 	RqDepth         = MetaGroup + "rq-depth"
 	IsRq            = MetaGroup + "is-rq"
 	IsSecondaryRoot = MetaGroup + "is-secondary-root"
+	IsUpperRp       = MetaGroup + "is-upper-rp"
+	UpperRp         = MetaGroup + "upper-rp"
 )
 
 // Finalizers
@@ -62,9 +64,9 @@ const (
 // IsRq offsets
 // Secondary Roots
 const (
-	SelfOffset      = 0
-	ParentOffset    = -1
-	ChildOffset     = 1
+	SelfOffset   = 0
+	ParentOffset = -1
+	ChildOffset  = 1
 )
 
 var (

--- a/internals/controllers/subnamespace_controller.go
+++ b/internals/controllers/subnamespace_controller.go
@@ -141,6 +141,7 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		return ctrl.Result{}, err
 	}
 	subspaceChilds, err := utils.NewObjectContextList(subspace.Ctx, subspace.Log, subspace.Client, &danav1.SubnamespaceList{}, client.InNamespace(namespace.Object.GetName()))
+
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -223,6 +224,10 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+
+	if err := utils.AppendUpperResourcePoolAnnotation(subspace, subspaceparent); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	r.addSnsChildNamespaceEvent(subspace)

--- a/internals/utils/helper.go
+++ b/internals/utils/helper.go
@@ -31,6 +31,61 @@ func IsChildlessNamespace(namespace *ObjectContext) bool {
 	return false
 }
 
+// IsUpperResourcePool returns true if the subnamespace is an upper resource pool
+// it happens only when the parent is from subnamespace kind or is a root namespace
+func IsUpperResourcePool(sns *ObjectContext) (bool, error) {
+	isResourcePool, _ := sns.Object.GetLabels()[danav1.ResourcePool]
+	parentNs, err := NewObjectContext(sns.Ctx, sns.Log, sns.Client, types.NamespacedName{Name: sns.Object.GetNamespace()}, &corev1.Namespace{})
+	if err != nil {
+		return false, err
+	}
+	parentSns, err := NewObjectContext(sns.Ctx, sns.Log, sns.Client, types.NamespacedName{Name: parentNs.Object.GetName(), Namespace: GetNamespaceParent(parentNs.Object)}, &danav1.Subnamespace{})
+	if err != nil {
+		return false, err
+	}
+	parentRole, _ := parentNs.Object.GetAnnotations()[danav1.Role]
+	isParentResourcePool, _ := parentSns.Object.GetLabels()[danav1.ResourcePool]
+	if (isResourcePool == "true") && (parentRole == danav1.Root || isParentResourcePool == "false") {
+		return true, nil
+	}
+	return false, nil
+}
+
+// AppendUpperResourcePoolAnnotation appends annotation to determine if the subnamespace is an upper resourcepool
+// if the sns has an upper resourcepool it appends an annotation with the upper resourcepool name
+func AppendUpperResourcePoolAnnotation(sns *ObjectContext, parentSns *ObjectContext) error {
+	isUpperResourcePool, err := IsUpperResourcePool(sns)
+	if err != nil {
+		return err
+	}
+	if isUpperResourcePool {
+		if err = sns.AppendAnnotations(map[string]string{danav1.IsUpperRp: danav1.True}); err != nil {
+			return err
+		}
+	} else {
+		if err = sns.AppendAnnotations(map[string]string{danav1.IsUpperRp: danav1.False}); err != nil {
+			return err
+		}
+	}
+
+	isParentUpperResourcePool, _ := parentSns.Object.GetAnnotations()[danav1.IsUpperRp]
+	if err != nil {
+		return err
+	}
+	if isParentUpperResourcePool == danav1.True {
+		if err = sns.AppendAnnotations(map[string]string{danav1.UpperRp: parentSns.GetName()}); err != nil {
+			return err
+		}
+	}
+	upperRp, exists := parentSns.Object.GetAnnotations()[danav1.UpperRp]
+	if exists {
+		if err = sns.AppendAnnotations(map[string]string{danav1.UpperRp: upperRp}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // IsRq returns true if the depth of the subnamespace is less or equal
 // the pre-set rqDepth AND if the subnamespace is not a ResourcePool
 func IsRq(sns *ObjectContext, offset int) (bool, error) {

--- a/internals/webhooks/subnamespace_webhook.go
+++ b/internals/webhooks/subnamespace_webhook.go
@@ -161,9 +161,17 @@ func (a *SubNamespaceAnnotator) Handle(ctx context.Context, req admission.Reques
 			return admission.Allowed(allowMessageValidateQuotaObj)
 		}
 
-		if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
-			return admission.Denied(err.Error())
+		isRp, _ := sns.Object.GetLabels()[danav1.ResourcePool]
+		isUpperRp, _ := sns.Object.GetAnnotations()[danav1.IsUpperRp]
+		// Only check the validity of the request if the subnamespace is not a ResourcePool OR the subnamespace is the upper ResourcePool
+		// this is because only in that case the subnamespace would have a RQ or CRQ attached to it.
+		// Otherwise, the subnamespace is part of a ResourcePool (and does not have a RQ/CRQ attached to it) and hence this check is unneeded.
+		if isRp != "true" || isUpperRp == danav1.True {
+			if err := ValidateUpdateSnsRequest(parentQuotaObj, sns, oldSns, myQuotaObj); err != nil {
+				return admission.Denied(err.Error())
+			}
 		}
+
 		if resourceName := snsChangedObject(oldSns, sns); len(resourceName) > 0 {
 			if !utils.UsernameToFilter(req.UserInfo.Username) {
 				//Write relevant log to elastic


### PR DESCRIPTION
Fixes [#25](https://github.com/dana-team/hns/issues/25). With this PR it is now possible to convert a Subnamespace to a ResourcePool. This change also includes `is-upper-rp` and `upper-rp` annotations addition.