### PR TITLE
fixes update quota problem that makes resource stuck

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -21,11 +21,11 @@ const (
 )
 
 const (
-	Root   			string = "root"
-	NoRole 			string = "none"
-	Leaf   			string = "leaf"
-	True   			string = "True"
-	False  			string = "False"
+	Root   string = "root"
+	NoRole string = "none"
+	Leaf   string = "leaf"
+	True   string = "True"
+	False  string = "False"
 )
 
 // MetaGroup
@@ -62,9 +62,9 @@ const (
 // IsRq offsets
 // Secondary Roots
 const (
-	SelfOffset      = 0
-	ParentOffset    = -1
-	ChildOffset     = 1
+	SelfOffset   = 0
+	ParentOffset = -1
+	ChildOffset  = 1
 )
 
 var (


### PR DESCRIPTION
Fixes #27. With this commit we now check in a loop if the subnamespace has been properly and fully updated before doing the entire updatequota operation. In essence this makes the reconciliation of the subnamespaces involved in the updatequota to be sequential instead of random, which caused an issue with updatequota failing.