### PR TITLE
add validation for subanmespace to make sure it includes all needed resourcequota paramaters

### DIFF
--- a/internals/webhooks/webhooks_messages.go
+++ b/internals/webhooks/webhooks_messages.go
@@ -24,4 +24,6 @@ const (
 	denyMessageNamespaceNotFound                    = "%v namespace not found"
 	allowMessageUpdatePhase                         = "Updated phase"
 	denyCannotGetClusterName                        = "Cannot get cluster name"
+	denyMessageNegativeRequest                      = "it's forbidden to create a subnamespace with negative amount of "
+	denyMessageWithoutResourceRequest               = "it's forbidden to create a subnamespace without providing requested amount of "
 )


### PR DESCRIPTION
Fixes issue #32. With this PR, it's no longer possible to create a subnamespace without having all parameters set in the resourcequota parameters. In addition, it's not possible to request a negative amount of a resource when creating a subnamespace.