### PR TITLE
fix validation webhook for moving to resourcepool

### DIFF
--- a/internals/webhooks/subnamespace_webhook.go
+++ b/internals/webhooks/subnamespace_webhook.go
@@ -129,12 +129,6 @@ func (a *SubNamespaceAnnotator) Handle(ctx context.Context, req admission.Reques
 			return admission.Denied(denyMessageUpdateResourcePool)
 		}
 
-		if validChange, err := oneOfSnsDescendantIsResourcePool(oldSns, sns); err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		} else if !validChange {
-			return admission.Denied(denyMessageUpdateResourcePoolDescendant)
-		}
-
 		if isExists, err := isSnsQuotaObjExists(sns); err != nil {
 			log.Error(err, "unable to get sns quota object")
 			return admission.Denied(err.Error())


### PR DESCRIPTION
Fixes #24. PR #31 fixed the issue for moving to resourcepool even if one of the descendants is already a resourcepool
because that pr add support for moving all the hierarchy from subnamespace to resourcepool even if one of the descendants is already a resourcepool. so we need to remove the denied from the webhook.