### PR TITLE
deny update of updatequota object in webhook

### DIFF
--- a/internals/webhooks/migrationhierarchy_webhook.go
+++ b/internals/webhooks/migrationhierarchy_webhook.go
@@ -156,7 +156,7 @@ func (a *MigrationHierarchyAnnotator) Handle(ctx context.Context, req admission.
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if !reflect.DeepEqual(migrationObject.Object.(*danav1.MigrationHierarchy).Spec, oldObj.Spec) {
-			return admission.Denied("you can't update this object")
+			return admission.Denied("It is forbidden to update an object of type " + oldObj.TypeMeta.Kind)
 		}
 		return admission.Allowed(allowMessageUpdatePhase)
 	}


### PR DESCRIPTION
Fixes #36. With this PR, it's no longer possible to update an updatequota object after it's completed. Also, this PR fixed the log of the denied in the MigrationHierarchy webhook.