### PR TITLE
fixed update of descendant namespaces in migrationhierarchy

### DIFF
--- a/internals/utils/helper.go
+++ b/internals/utils/helper.go
@@ -216,7 +216,10 @@ func UpdateAllNsChildsOfNs(nsparent *ObjectContext) error {
 		if err != nil {
 			return err
 		}
-		return UpdateAllNsChildsOfNs(ns)
+		err = UpdateAllNsChildsOfNs(ns)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #49. With this PR, the namespaces in the hierarchy under the subnamespace that gets migrated are now all updated properly with correct labels and annotations. Previously, only the first child subnamespace of the subnamespace that got migrated was being updated correctly.