### PR TITLE
fixed update of descendant subnamespace in migrationhierarchy

### DIFF
--- a/internals/controllers/subnamespace_controller.go
+++ b/internals/controllers/subnamespace_controller.go
@@ -258,6 +258,10 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		}
 
 	}
+	if err := subspace.AppendAnnotations(map[string]string{danav1.DisplayName: utils.GetNamespaceDisplayName(ownerNamespace.Object) + "/" + subspace.Object.GetName()}); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if err := subspace.UpdateObject(func(object client.Object, log logr.Logger) (client.Object, logr.Logger) {
 		object.(*danav1.Subnamespace).Status.Namespaces = childrenRequests
 		object.(*danav1.Subnamespace).Status.Total.Allocated = allocated

--- a/internals/utils/helper.go
+++ b/internals/utils/helper.go
@@ -221,7 +221,33 @@ func UpdateAllNsChildsOfNs(nsparent *ObjectContext) error {
 			return err
 		}
 	}
+
 	return nil
+}
+
+// GetAllObjectChildren takes one paramater: rootObject
+// then return a slice of all the descendants of the root object(including the root itself)
+func GetAllObjectChildren(rootObject *ObjectContext) []*ObjectContext {
+	if rootObject == nil {
+		return []*ObjectContext{}
+	}
+	var subspaceDescendant []*ObjectContext
+	subspaceChilds, err := NewObjectContextList(rootObject.Ctx, rootObject.Log, rootObject.Client, &danav1.SubnamespaceList{}, client.InNamespace(rootObject.Object.GetName()))
+	if err != nil {
+		return nil
+	}
+	for _, objectItem := range subspaceChilds.Objects.(*danav1.SubnamespaceList).Items {
+		var object *ObjectContext
+		if isNamespace(rootObject.Object) {
+			object, _ = NewObjectContext(rootObject.Ctx, rootObject.Log, rootObject.Client, types.NamespacedName{Name: objectItem.GetName()}, &corev1.Namespace{})
+		} else {
+			object, _ = NewObjectContext(rootObject.Ctx, rootObject.Log, rootObject.Client, types.NamespacedName{Name: objectItem.GetName(), Namespace: objectItem.GetNamespace()}, &danav1.Subnamespace{})
+		}
+		childrenObject := GetAllObjectChildren(object)
+		subspaceDescendant = append(subspaceDescendant, childrenObject...)
+	}
+
+	return append([]*ObjectContext{rootObject}, subspaceDescendant...)
 }
 
 func IndexOf(element string, arr []string) (int, error) {


### PR DESCRIPTION
Fixes #51. With this PR, the subnamespaces in the hierarchy under the subnamespace that gets migrated are now all updated properly with correct DisplayName. Previously, only the first child subnamespace of the subnamespace that got migrated was being updated correctly.