### PR TITLE
added annotation to subnamespace to indicate what its crq is

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -53,6 +53,7 @@ const (
 	IsSecondaryRoot = MetaGroup + "is-secondary-root"
 	IsUpperRp       = MetaGroup + "is-upper-rp"
 	UpperRp         = MetaGroup + "upper-rp"
+	CrqPointer      = MetaGroup + "crq-pointer"
 )
 
 // Finalizers

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/danateamorg/hns-manual
-  newTag: v0.18
+  newTag: v0.20

--- a/internals/controllers/subnamespace_controller.go
+++ b/internals/controllers/subnamespace_controller.go
@@ -236,6 +236,12 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 			return ctrl.Result{}, err
 		}
 	}
+	crqPointer := utils.GetCrqPointer(subspace.Object)
+	if crqPointer != "" {
+		if err = subspace.AppendAnnotations(map[string]string{danav1.CrqPointer: crqPointer }); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	if err := utils.AppendUpperResourcePoolAnnotation(subspace, subspaceparent); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -274,8 +280,8 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 				return ctrl.Result{}, err
 			}
 		}
-}
-  if err := subspace.AppendAnnotations(map[string]string{danav1.DisplayName: utils.GetNamespaceDisplayName(ownerNamespace.Object) + "/" + subspace.Object.GetName()}); err != nil {
+	}
+	if err := subspace.AppendAnnotations(map[string]string{danav1.DisplayName: utils.GetNamespaceDisplayName(ownerNamespace.Object) + "/" + subspace.Object.GetName()}); err != nil {
 		return ctrl.Result{}, err
 	}
 	if utils.IsUpdateNeeded(subspace.Object, childrenRequests, allocated, free) {
@@ -287,6 +293,7 @@ func (r *SubnamespaceReconciler) Sync(ownerNamespace *utils.ObjectContext, subsp
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internals/utils/quotaHelper.go
+++ b/internals/utils/quotaHelper.go
@@ -241,3 +241,20 @@ func addQuantityToResourceList(resourceList corev1.ResourceList, resourceName co
 		resourceList[resourceName] = quantity
 	}
 }
+
+// GetCrqPointer gets a subnamespace and returns its crq pointer.
+// If it has a crq (which means it's a subns or upper rp), it returns its name.
+// If it doesn't, it returns the upper resourcepool's name.
+func GetCrqPointer(subns client.Object) string {
+	if subns.GetAnnotations()[danav1.IsRq] == danav1.True{
+		return ""
+	}
+	if subns.GetLabels()[danav1.ResourcePool] == "false" ||
+		subns.GetAnnotations()[danav1.IsUpperRp] == danav1.True {
+		return subns.GetName()
+	}
+	return subns.GetAnnotations()[danav1.UpperRp]
+ 
+ 
+ }
+ 

--- a/internals/utils/quotaHelper.go
+++ b/internals/utils/quotaHelper.go
@@ -254,7 +254,5 @@ func GetCrqPointer(subns client.Object) string {
 		return subns.GetName()
 	}
 	return subns.GetAnnotations()[danav1.UpperRp]
- 
- 
  }
  

--- a/test/e2e/subnamespace_test.go
+++ b/test/e2e/subnamespace_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Subnamespaces", func() {
 		// verify subnamespace annotations
 		FieldShouldContain("subnamespace", nsRoot, nsA, ".metadata.annotations", danav1.IsRq+":"+danav1.True)
 		FieldShouldContain("subnamespace", nsA, nsB, ".metadata.annotations", danav1.IsRq+":"+danav1.True)
+		FieldShouldContain("subnamespace", nsB, nsC, ".metadata.annotations", danav1.CrqPointer+":"+nsC)
 		FieldShouldContain("subnamespace", nsB, nsC, ".metadata.annotations", danav1.IsRq+":"+danav1.False)
 		FieldShouldContain("subnamespace", nsB, nsC, ".metadata.annotations", danav1.IsUpperRp+":"+danav1.False)
 		FieldShouldContain("subnamespace", nsB, nsC, ".metadata.annotations", "openshift.io/display-name:"+nsRoot+"/"+nsA+"/"+nsB+"/"+nsC)


### PR DESCRIPTION
Fixes #56. If the subnamespace has a crq, it points to it. However, if it doesn't have (which means its a resourcepool but not the upper one) it points to the upper rp.