### PR TITLE
modified rbac permissions for controller

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/danateamorg/hns-manual
-  newTag: v0.90
+  newTag: v0.91

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -17,16 +17,21 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
+  - coordination.k8s.io
   resources:
-  - configmaps/status
+  - leases
   verbs:
   - get
+  - list
+  - watch
+  - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
+  - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,42 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - users
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create
@@ -60,6 +96,12 @@ rules:
 - apiGroups:
   - dana.hns.io
   resources:
+  - subnamespaces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - dana.hns.io
+  resources:
   - subnamespaces/status
   verbs:
   - get
@@ -86,6 +128,44 @@ rules:
   - patch
   - update
 - apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
@@ -105,3 +185,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - bind
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internals/controllers/migrationhierarchy/migrationhierarchy_controller.go
+++ b/internals/controllers/migrationhierarchy/migrationhierarchy_controller.go
@@ -47,6 +47,7 @@ type MigrationHierarchyReconciler struct {
 
 // +kubebuilder:rbac:groups=dana.hns.io,resources=migrationhierarchies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dana.hns.io,resources=migrationhierarchies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=users,verbs=impersonate
 
 func (r *MigrationHierarchyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internals/controllers/namespace/namespace_controller.go
+++ b/internals/controllers/namespace/namespace_controller.go
@@ -44,6 +44,8 @@ type NamespaceReconciler struct {
 
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;escalate;bind
 
 // SetupWithManager sets up the controller by specifying the following: controller is managing the reconciliation
 // of Namespace objects, it is watching for changes to the NSEvents channel and enqueues requests for the

--- a/internals/controllers/namespace/utils.go
+++ b/internals/controllers/namespace/utils.go
@@ -66,12 +66,12 @@ func composeNsHnsViewClusterRole(namespaceName string) *rbacv1.ClusterRole {
 
 				ResourceNames: []string{namespaceName}}, {
 				Verbs:     []string{"get"},
-				APIGroups: []string{"core"},
+				APIGroups: []string{""},
 				Resources: []string{"resourcequotas"},
 
 				ResourceNames: []string{namespaceName}}, {
 				Verbs:     []string{"list"},
-				APIGroups: []string{"core"},
+				APIGroups: []string{""},
 				Resources: []string{"resourcequotas"},
 			},
 		},

--- a/internals/controllers/rolebinding/rolebinding_controller.go
+++ b/internals/controllers/rolebinding/rolebinding_controller.go
@@ -39,6 +39,7 @@ type RoleBindingReconciler struct {
 
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch;delete;bind
 
 // SetupWithManager sets up the controller by specifying the following: indexes the "rb.propagate" field for
 // RoleBindings, filters events to only include RoleBindings that are part of a namespace with

--- a/internals/controllers/subnamespace/subnamespace_controller.go
+++ b/internals/controllers/subnamespace/subnamespace_controller.go
@@ -42,6 +42,11 @@ type snsPhaseFunc func(*utils.ObjectContext, *utils.ObjectContext) (ctrl.Result,
 
 // +kubebuilder:rbac:groups=dana.hns.io,resources=subnamespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dana.hns.io,resources=subnamespaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dana.hns.io,resources=subnamespaces/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=namespaces/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="quota.openshift.io",resources=clusterresourcequotas,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;list;watch;create;update;patch;delete
 
 // SetupWithManager sets up the controller by specifying the following: controller is managing the reconciliation
 // of subnamespace objects and is watching for changes to the SNSEvents channel and enqueues requests for the

--- a/internals/controllers/updatequota/updatequota_controller.go
+++ b/internals/controllers/updatequota/updatequota_controller.go
@@ -36,6 +36,7 @@ type UpdateQuotaReconciler struct {
 
 // +kubebuilder:rbac:groups=dana.hns.io,resources=updatequota,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dana.hns.io,resources=updatequota/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=users,verbs=impersonate
 
 func (r *UpdateQuotaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
Fixes #88. With this PR, kubebuilder markers have been added to make the controller run properly without cluster admin permissions