### PR TITLE
Update pre-merged workflow

### DIFF
--- a/.github/workflows/pre-merge-check.yml
+++ b/.github/workflows/pre-merge-check.yml
@@ -1,17 +1,43 @@
-name: Pre Merge Check
+name: Pre Merge
 
 on:
   pull_request:
+    branches:
+      - main
     types: [opened, reopened, synchronize]
-
 jobs:
-  go-vet:
+  e2e-tests:
+    name: e2e-tests
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      REPOSITORY_NAME: ${{ github.repository }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
-    - name: Go Vet
-      run: go vet ./...
+      - name: Set Kubernetes context
+        uses: Azure/k8s-set-context@v3.0
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.HNS_CI_CLUSTER }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          go-version: '1.20'
+      - name: Run go vet
+        run: go vet ./...
+      - name: Log into ghcr.io
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add IMAGE_TAG env property with commit short sha
+        run: echo "IMAGE_TAG=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      - name: Build and push docker image
+        run: make docker-build docker-push IMG=${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}:${IMAGE_TAG}
+      - name: Deploy HNS
+        run: make install deploy IMG=${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}:${IMAGE_TAG}
+      - name: Run e2e tests
+        run: make test-e2e


### PR DESCRIPTION
This commit refactors the pre-merged workflow to enhance the CI/CD pipeline for pull requests. The changes include:

- Adding a new job named "e2e-tests" that performs end-to-end tests.
- Setting up environment variables for the Docker registry and repository details.
- Adding steps to log into ghcr.io, build and push a Docker image, and deploy to the HNS CI cluster.
- Running end-to-end tests using the 'make test-e2e' command.
- Restricting the workflow to trigger only on pull requests targeting the 'main' branch.