### PR TITLE
Added validation logic on subnamespace delete

### DIFF
--- a/config/webhook-dev/manifests.yaml
+++ b/config/webhook-dev/manifests.yaml
@@ -104,6 +104,7 @@ webhooks:
       - operations:
           - CREATE
           - UPDATE
+          - DELETE
         apiGroups:
           - dana.hns.io
         apiVersions:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -107,6 +107,7 @@ webhooks:
     apiVersions:
     - v1
     operations:
+    - DELETE
     - CREATE
     - UPDATE
     resources:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.6
 
 require (
 	github.com/go-logr/logr v1.4.1
-	github.com/onsi/ginkgo/v2 v2.15.0
+	github.com/onsi/ginkgo/v2 v2.16.0
 	github.com/onsi/gomega v1.31.1
 	github.com/openshift/api v0.0.0-20240111155829-b6df9ba0be95
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
+github.com/onsi/ginkgo/v2 v2.16.0 h1:7q1w9frJDzninhXxjZd+Y/x54XNjG/UlRLIYPZafsPM=
+github.com/onsi/ginkgo/v2 v2.16.0/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
 github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openshift/api v0.0.0-20240111155829-b6df9ba0be95 h1:j0eYo5xy/lW+oeLvpbtJBNc7bvbiuJaW7ZXBoQ8gsjw=

--- a/internal/subnamespace/deletevalidator.go
+++ b/internal/subnamespace/deletevalidator.go
@@ -1,0 +1,24 @@
+package subnamespace
+
+import (
+	"fmt"
+	danav1 "github.com/dana-team/hns/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// handleDelete implements the logic for the deletion of a subnamespace
+func (v *SubnamespaceValidator) handleDelete(req admission.Request) admission.Response {
+
+	response := v.validateServiceAccount(req.UserInfo.Username)
+	return response
+}
+
+// validateServiceAccount validates that the account requesting the deletion of a subnamespace
+// is the service account of the sns operator. Otherwise it will deny the request
+func (v *SubnamespaceValidator) validateServiceAccount(userName string) admission.Response {
+	if userName != fmt.Sprintf("system:serviceaccount:%s:%s", danav1.SNSNamespace, danav1.SNSServiceAccount) {
+		return admission.Denied(fmt.Sprintf("%s is not allowed to delete subnamespaces", userName))
+
+	}
+	return admission.Allowed("")
+}

--- a/test/e2e/resourcepool_test.go
+++ b/test/e2e/resourcepool_test.go
@@ -42,7 +42,7 @@ var _ = Describe("ResourcePool", func() {
 		FieldShouldContain("subnamespace", nsB, nsC, ".metadata.annotations", danav1.IsUpperRp+":"+danav1.True)
 
 		// delete subnamespace
-		MustRun("kubectl delete subnamespace", nsC, "-n", nsB)
+		MustRun("kubectl delete namespace", nsC, "-n", nsB)
 	})
 
 	It("should create a resourcepool under a resourcepool and update the labels accordingly", func() {
@@ -95,7 +95,7 @@ var _ = Describe("ResourcePool", func() {
 		CreateSubnamespace(nsC, nsB, randPrefix, true, storage, "10Gi", cpu, "10", memory, "10Gi", pods, "10", gpu, "10")
 		CreateSubnamespace(nsD, nsC, randPrefix, true)
 
-		MustRun("kubectl delete subnamespace -n", nsC, nsD)
+		MustRun("kubectl delete namespace -n", nsC, nsD)
 	})
 
 	It("should create a clusterresourcequota for a resourcepool regardless of its depth only if it's upper", func() {

--- a/test/e2e/subnamespace_test.go
+++ b/test/e2e/subnamespace_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Subnamespaces", func() {
 		FieldShouldContain("clusterresourcequota", "", nsC, ".metadata.name", nsC)
 
 		// delete subnamespace
-		MustRun("kubectl delete subnamespace", nsC, "-n", nsB)
+		MustRun("kubectl delete namespace", nsC, "-n", nsB)
 	})
 
 	It("should create a subnamespace and namespace with the needed labels and annotations", func() {
@@ -282,6 +282,13 @@ var _ = Describe("Subnamespaces", func() {
 		for i := range danav1.DefaultAnnotations {
 			FieldShouldContain("namespace", "", nsB, ".metadata.annotations", danav1.DefaultAnnotations[i])
 		}
+	})
+	It("should fail when deleting a subnamespace directly", func() {
+		nsA := GenerateE2EName("a", testPrefix, randPrefix)
+
+		CreateSubnamespace(nsA, nsRoot, randPrefix, false, storage, "50Gi", cpu, "50", memory, "50Gi", pods, "50", gpu, "50")
+		MustNotRun("kubectl delete subnamespace", nsA)
+
 	})
 
 })


### PR DESCRIPTION
Fixes #112
This PR introduces additional logic to the subnamespace validating webhook. From now on, only the hns service account can delete a subnamespace, everything else will be denied automatically.