### PR TITLE
requester annotation webhook

### DIFF
--- a/config/webhook-dev/manifests.yaml
+++ b/config/webhook-dev/manifests.yaml
@@ -27,6 +27,40 @@ webhooks:
       - v1beta1
     failurePolicy: Fail
     timeoutSeconds: 30
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      url: https://$(DANA_DEV_VM):9443/mutate-v1-migrationhierarchy
+    failurePolicy: Fail
+    name: migrationhierarchy.dana.io
+    rules:
+      - apiGroups:
+          - dana.hns.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - migrationhierarchies
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      url: https://$(DANA_DEV_VM):9443/mutate-v1-updatequota
+    failurePolicy: Fail
+    name: updatequota.dana.io
+    rules:
+      - apiGroups:
+          - dana.hns.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - updatequota
+    sideEffects: NoneOnDryRun
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,6 +24,46 @@ webhooks:
     resources:
     - buildconfigs
   sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-migrationhierarchy
+  failurePolicy: Fail
+  name: migrationhierarchy.dana.io
+  rules:
+  - apiGroups:
+    - dana.hns.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - migrationhierarchies
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-updatequota
+  failurePolicy: Fail
+  name: updatequota.dana.io
+  rules:
+  - apiGroups:
+    - dana.hns.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - updatequota
+  sideEffects: NoneOnDryRun
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/internal/migrationhierarchy/mutator.go
+++ b/internal/migrationhierarchy/mutator.go
@@ -1,0 +1,48 @@
+package migrationhierarchy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	danav1 "github.com/dana-team/hns/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type MigrationHierarchyMutator struct {
+	Client  client.Client
+	Decoder *admission.Decoder
+}
+
+// +kubebuilder:webhook:path=/mutate-v1-migrationhierarchy,mutating=true,sideEffects=NoneOnDryRun,failurePolicy=fail,groups="dana.hns.io",resources=migrationhierarchies,verbs=create,versions=v1,name=migrationhierarchy.dana.io,admissionReviewVersions=v1;v1beta1
+
+// Handle implements the mutation webhook.
+func (m *MigrationHierarchyMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx).WithValues("webhook", "MigrationHierarchy mutation Webhook")
+	logger.Info("webhook request received")
+
+	migrationHierarchy := danav1.MigrationHierarchy{}
+	if err := m.Decoder.DecodeRaw(req.Object, &migrationHierarchy); err != nil {
+		logger.Error(err, "failed to decode object", "request object", req.Object)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	marshalMigrationHierarchy, err := m.UpdateRequester(migrationHierarchy, req.UserInfo.Username)
+	if err != nil {
+		logger.Error(err, "failed to marshal object", "object", migrationHierarchy)
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalMigrationHierarchy)
+}
+
+// UpdateRequester adds a requester annotation to the object
+func (m *MigrationHierarchyMutator) UpdateRequester(migrationHierarchyObject danav1.MigrationHierarchy, requester string) ([]byte, error) {
+	migrationHierarchyObject.Annotations["requester"] = requester
+	marshalUpdateQuota, err := json.Marshal(migrationHierarchyObject)
+	if err != nil {
+		return nil, err
+	}
+	return marshalUpdateQuota, nil
+}

--- a/internal/setup/webhooks.go
+++ b/internal/setup/webhooks.go
@@ -50,6 +50,14 @@ func Webhooks(mgr manager.Manager, ndb *namespacedb.NamespaceDB, scheme *runtime
 		Client:  mgr.GetClient(),
 		Decoder: decoder,
 	}})
+	hookServer.Register("/mutate-v1-migrationhierarchy", &webhook.Admission{Handler: &MigrationHierarchyMutator{
+		Client:  mgr.GetClient(),
+		Decoder: decoder,
+	}})
+	hookServer.Register("/mutate-v1-updatequota", &webhook.Admission{Handler: &UpdateQuotaMutator{
+		Client:  mgr.GetClient(),
+		Decoder: decoder,
+	}})
 
 	hookServer.Register("/validate-v1-updatequota", &webhook.Admission{Handler: &UpdateQuotaValidator{
 		Client:  mgr.GetClient(),

--- a/internal/updatequota/mutator.go
+++ b/internal/updatequota/mutator.go
@@ -1,0 +1,47 @@
+package updatequota
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	danav1 "github.com/dana-team/hns/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type UpdateQuotaMutator struct {
+	Client  client.Client
+	Decoder *admission.Decoder
+}
+
+// +kubebuilder:webhook:path=/mutate-v1-updatequota,mutating=true,sideEffects=NoneOnDryRun,failurePolicy=fail,groups="dana.hns.io",resources=updatequota,verbs=create,versions=v1,name=updatequota.dana.io,admissionReviewVersions=v1;v1beta1
+
+// Handle implements the mutation webhook.
+func (m *UpdateQuotaMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx).WithValues("webhook", "UpdateQuota mutation Webhook")
+	logger.Info("webhook request received")
+	updateQuota := danav1.Updatequota{}
+	if err := m.Decoder.DecodeRaw(req.Object, &updateQuota); err != nil {
+		logger.Error(err, "failed to decode object", "request object", req.Object)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	marshalUpdateQuota, err := m.UpdateRequester(updateQuota, req.UserInfo.Username)
+	if err != nil {
+		logger.Error(err, "failed to marshal object", "object", updateQuota)
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalUpdateQuota)
+}
+
+// UpdateRequester adds a requester annotation to the object
+func (m *UpdateQuotaMutator) UpdateRequester(updateQuotaObject danav1.Updatequota, requester string) ([]byte, error) {
+	updateQuotaObject.Annotations["requester"] = requester
+	marshalUpdateQuota, err := json.Marshal(updateQuotaObject)
+	if err != nil {
+		return nil, err
+	}
+	return marshalUpdateQuota, nil
+}

--- a/test/e2e_tests/migrationhierarchy_test.go
+++ b/test/e2e_tests/migrationhierarchy_test.go
@@ -43,7 +43,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsE, nsC, randPrefix, false, storage, "5Gi", cpu, "5", memory, "5Gi", pods, "5", gpu, "5")
 		CreateSubnamespace(nsF, nsD, randPrefix, false, storage, "1Gi", cpu, "1", memory, "1Gi", pods, "1", gpu, "1")
 
-		mhName := CreateMigrationHierarchy(nsF, nsE)
+		mhName := CreateMigrationHierarchy(nsF, nsE, "")
 
 		// make sure the subnamespace was migrated and the parent was updated
 		FieldShouldContain("subnamespace", nsE, nsF, ".metadata.namespace", nsE)
@@ -52,6 +52,22 @@ var _ = Describe("MigrationHierarchy", func() {
 		// verify phase is complete before labeling it
 		FieldShouldContain("migrationhierarchy", "", mhName, ".status.phase", "Complete")
 		LabelTestingMigrationHierarchies(mhName, randPrefix)
+	})
+
+	It("should add a requester annotation to the migrationhierarchy object with the account name", func() {
+		nsA := GenerateE2EName("a", testPrefix, randPrefix)
+		nsB := GenerateE2EName("b", testPrefix, randPrefix)
+		CreateSubnamespace(nsA, nsRoot, randPrefix, false, storage, "50Gi", cpu, "50", memory, "50Gi", pods, "50", gpu, "50")
+		CreateSubnamespace(nsB, nsRoot, randPrefix, false, storage, "25Gi", cpu, "25", memory, "25Gi", pods, "25", gpu, "25")
+
+		userA := GenerateE2EUserName("user-a")
+		CreateUser(userA, randPrefix)
+		GrantTestingUserClusterAdmin(userA)
+
+		mhName := CreateMigrationHierarchy(nsA, nsB, userA)
+
+		FieldShouldContain("migrationhierarchy", "", mhName, ".metadata.annotations.requester", userA)
+
 	})
 
 	It("should migrate subnamespace that doesn't have a CRQ and their direct parent doesn't have a CRQ,", func() {
@@ -66,7 +82,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsC, nsA, randPrefix, false, storage, "25Gi", cpu, "25", memory, "25Gi", pods, "25", gpu, "25")
 		CreateSubnamespace(nsD, nsB, randPrefix, false, storage, "10Gi", cpu, "10", memory, "10Gi", pods, "10", gpu, "10")
 
-		mhName := CreateMigrationHierarchy(nsD, nsC)
+		mhName := CreateMigrationHierarchy(nsD, nsC, "")
 
 		// verify phase is complete before labeling it
 		FieldShouldContain("migrationhierarchy", "", mhName, ".status.phase", "Complete")
@@ -91,7 +107,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsE, nsD, randPrefix, false, storage, "2Gi", cpu, "2", memory, "2Gi", pods, "2", gpu, "2")
 		CreateSubnamespace(nsF, nsE, randPrefix, false, storage, "1Gi", cpu, "1", memory, "1Gi", pods, "1", gpu, "1")
 
-		mhName := CreateMigrationHierarchy(nsD, nsA)
+		mhName := CreateMigrationHierarchy(nsD, nsA, "")
 
 		// verify phase is complete before labeling it
 		FieldShouldContain("migrationhierarchy", "", mhName, ".status.phase", "Complete")
@@ -120,7 +136,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsA, nsRoot, randPrefix, false, storage, "50Gi", cpu, "50", memory, "50Gi", pods, "50", gpu, "50")
 		CreateSubnamespace(nsC, nsA, randPrefix, false, storage, "25Gi", cpu, "25", memory, "25Gi", pods, "25", gpu, "25")
 
-		mhName := CreateMigrationHierarchy(nsA, nsF)
+		mhName := CreateMigrationHierarchy(nsA, nsF, "")
 
 		// verify phase is complete before labeling it
 		FieldShouldContain("migrationhierarchy", "", mhName, ".status.phase", "Complete")
@@ -153,7 +169,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsG, nsF, randPrefix, false, storage, "1Gi", cpu, "1", memory, "1Gi", pods, "1", gpu, "1")
 		CreateSubnamespace(nsH, nsG, randPrefix, false, storage, "1Gi", cpu, "1", memory, "1Gi", pods, "1", gpu, "1")
 
-		mhName := CreateMigrationHierarchy(nsF, nsE)
+		mhName := CreateMigrationHierarchy(nsF, nsE, "")
 
 		// make sure the subnamespace was migrated and the parent was updated
 		FieldShouldContain("subnamespace", nsE, nsF, ".metadata.namespace", nsE)
@@ -185,7 +201,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsD, nsC, randPrefix, false, storage, "10Gi", cpu, "10", memory, "10Gi", pods, "10", gpu, "10")
 		CreateSubnamespace(nsE, nsD, randPrefix, false, storage, "5Gi", cpu, "5", memory, "5Gi", pods, "5", gpu, "5")
 
-		mhName := CreateMigrationHierarchy(nsE, nsC)
+		mhName := CreateMigrationHierarchy(nsE, nsC, "")
 
 		// make sure the subnamespace was migrated and the parent was updated
 		FieldShouldContain("subnamespace", nsC, nsE, ".metadata.namespace", nsC)
@@ -241,7 +257,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsG, nsF, randPrefix, true)
 		CreateSubnamespace(nsH, nsG, randPrefix, true)
 
-		mhName := CreateMigrationHierarchy(nsF, nsE)
+		mhName := CreateMigrationHierarchy(nsF, nsE, "")
 
 		// make sure the subnamespace was migrated and the parent was updated
 		FieldShouldContain("subnamespace", nsE, nsF, ".metadata.namespace", nsE)
@@ -284,7 +300,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsG, nsF, randPrefix, true)
 		CreateSubnamespace(nsH, nsG, randPrefix, true)
 
-		mhName := CreateMigrationHierarchy(nsF, nsI)
+		mhName := CreateMigrationHierarchy(nsF, nsI, "")
 
 		// make sure the subnamespace was migrated and the parent was updated
 		FieldShouldContain("subnamespace", nsI, nsF, ".metadata.namespace", nsI)
@@ -364,7 +380,7 @@ var _ = Describe("MigrationHierarchy", func() {
 		CreateSubnamespace(nsF, nsD, randPrefix, false, storage, "2Gi", cpu, "2", memory, "2Gi", pods, "2", gpu, "2")
 		CreateSubnamespace(nsG, nsF, randPrefix, true, storage, "2Gi", cpu, "2", memory, "2Gi", pods, "2", gpu, "2")
 
-		mhName := CreateMigrationHierarchy(nsD, nsI)
+		mhName := CreateMigrationHierarchy(nsD, nsI, "")
 		FieldShouldContain("subnamespace", nsH, nsI, ".spec.resourcequota.hard."+cpu, "6")
 		FieldShouldContain("subnamespace", nsH, nsI, ".spec.resourcequota.hard."+memory, "6Gi")
 		FieldShouldContain("subnamespace", nsH, nsI, ".spec.resourcequota.hard."+pods, "6")

--- a/test/testutils/composeutils.go
+++ b/test/testutils/composeutils.go
@@ -53,6 +53,11 @@ func GrantTestingUserAdmin(user, ns string) {
 	MustRun("kubectl create rolebinding", "test-admin-"+user+"-"+ns, "--user", user, "--namespace", ns, "--clusterrole admin")
 }
 
+// GrantTestingUserAdmin gives cluster-admin cluster-rolebinding to a user .
+func GrantTestingUserClusterAdmin(user string) {
+	MustRun("kubectl create clusterrolebinding", "test-cluster-admin-"+user, "--user", user, "--clusterrole cluster-admin")
+}
+
 // AnnotateNSSecondaryRoot annotates a namespace as secondary root.
 func AnnotateNSSecondaryRoot(ns string) {
 	MustRun("kubectl annotate --overwrite ns", ns, danav1.IsSecondaryRoot+"="+danav1.True)
@@ -134,10 +139,14 @@ func CreateUpdateQuota(nm, nsnm, dsnm, user string, args ...string) {
 }
 
 // CreateMigrationHierarchy creates the specified MigrationHierarchy.
-func CreateMigrationHierarchy(currentns, tons string) string {
+func CreateMigrationHierarchy(currentns, tons string, user string) string {
 	name := "from" + currentns + "to" + tons
 	mh := generateMigrartionHierarchyManifest(name, currentns, tons)
-	MustApplyYAML(mh)
+	if user != "" {
+		MustApplyYAMLAsUser(mh, user)
+	} else {
+		MustApplyYAML(mh)
+	}
 	RunShouldContain(name, propagationTime, "kubectl get migrationhierarchy")
 	return name
 }


### PR DESCRIPTION
Fixes #111 
This PR introduces a mutation webhook for migrationhierarchy and updatequoata. This webhook adds a "requester" annotation to any new object created with the name of the account that created it. It also adds test cases for this effect