### PR TITLE
peermitted groups for UQ and MH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.0
-
+PERMITTED_GROUPS="dana,test"
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	userv1 "github.com/openshift/api/user/v1"
 	"os"
 
 	danav1 "github.com/dana-team/hns/api/v1"
@@ -55,6 +56,7 @@ func init() {
 	utilruntime.Must(quotav1.Install(scheme))
 	utilruntime.Must(templatev1.Install(scheme))
 	utilruntime.Must(buildv1.Install(scheme))
+	utilruntime.Must(userv1.Install(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,5 @@
+generatorOptions:
+  disableNameSuffixHash: true
 resources:
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -6,3 +8,7 @@ images:
 - name: controller
   newName: controller
   newTag: latest
+configMapGenerator:
+  - name: permitted-groups-cm
+    literals:
+      - PERMITTEDGROUPS='dana,test'

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,9 +36,12 @@ spec:
           name: manager
           resources:
             limits:
-              cpu: 1
+              cpu: "1"
               memory: 1Gi
             requests:
-              cpu: 1
+              cpu: "1"
               memory: 1Gi
+          envFrom:
+            - configMapRef:
+                name: permitted-groups-cm
       terminationGracePeriodSeconds: 10

--- a/internal/migrationhierarchy/createvalidator.go
+++ b/internal/migrationhierarchy/createvalidator.go
@@ -73,7 +73,7 @@ func (v *MigrationHierarchyValidator) handleCreate(mhObject *objectcontext.Objec
 		}
 	}
 
-	if response := common.ValidatePermissions(ctx, currentNSSliced, currentNSName, toNSName, ancestorNSName, reqUser, false); !response.Allowed {
+	if response := common.ValidatePermissions(ctx, currentNSSliced, currentNSName, toNSName, ancestorNSName, reqUser, false, v.Client); !response.Allowed {
 		return response
 	}
 

--- a/internal/updatequota/createvalidator.go
+++ b/internal/updatequota/createvalidator.go
@@ -61,7 +61,7 @@ func (v *UpdateQuotaValidator) handleCreate(upqObject *objectcontext.ObjectConte
 		}
 	}
 
-	if response := common.ValidatePermissions(ctx, sourceNSSliced, sourceNSName, destNSName, ancestorNSName, username, true); !response.Allowed {
+	if response := common.ValidatePermissions(ctx, sourceNSSliced, sourceNSName, destNSName, ancestorNSName, username, true, v.Client); !response.Allowed {
 		return response
 	}
 

--- a/test/e2e_tests/updatequota_test.go
+++ b/test/e2e_tests/updatequota_test.go
@@ -15,6 +15,7 @@ var _ = Describe("UpdateQuota", func() {
 
 		CleanupTestNamespaces(randPrefix)
 		CleanupTestUsers(randPrefix)
+		CleanupTestGroup("test")
 
 		nsRoot = GenerateE2EName("root", testPrefix, randPrefix)
 		CreateRootNS(nsRoot, randPrefix, rqDepth)
@@ -24,6 +25,8 @@ var _ = Describe("UpdateQuota", func() {
 	AfterEach(func() {
 		CleanupTestNamespaces(randPrefix)
 		CleanupTestUsers(randPrefix)
+		CleanupTestGroup("test")
+
 	})
 
 	It("should move resources from the root namespace to a subnamespace", func() {
@@ -219,5 +222,20 @@ var _ = Describe("UpdateQuota", func() {
 
 		// verify after update
 		FieldShouldContain("subnamespace", nsA, nsC, ".status.total.free.pods", "25")
+	})
+	It("should allow the creation of an updatequota with a user in a permitted group", func() {
+		nsA := GenerateE2EName("a", testPrefix, randPrefix)
+		nsB := GenerateE2EName("b", testPrefix, randPrefix)
+		CreateSubnamespace(nsA, nsRoot, randPrefix, false, storage, "50Gi", cpu, "50", memory, "50Gi", pods, "50", gpu, "50")
+		CreateSubnamespace(nsB, nsRoot, randPrefix, false, storage, "25Gi", cpu, "25", memory, "25Gi", pods, "25", gpu, "25")
+
+		userA := GenerateE2EUserName("user-a")
+
+		CreateUser(userA, randPrefix)
+		CreateGroup("test", userA, randPrefix)
+		CreateUpdateQuota("updatequota-from-"+nsA+"-to-"+nsB, nsA, nsB, userA, "pods", "10")
+
+		FieldShouldContain("subnamespace", nsB, nsA, ".status.total.free.pods", "35")
+
 	})
 })

--- a/test/testutils/testutils.go
+++ b/test/testutils/testutils.go
@@ -16,6 +16,7 @@ import (
 const testingNamespaceLabel = "dana.hns.io/testNamespace"
 const testingMigrationHierarchyLabel = "dana.hns.io/testMigrationHierarchy"
 const testingUserLabel = "dana.hns.io/testUser"
+const testingGroupLabel = "dana.hns.io/testGroup"
 
 func FieldShouldContain(resource, ns, nm, field, want string) {
 	fieldShouldContainMultipleWithTimeout(1, resource, ns, nm, field, []string{want}, eventuallyTimeout)
@@ -219,6 +220,11 @@ func LabelTestingMigrationHierarchies(mh, randPrefix string) {
 	MustRun("kubectl label --overwrite migrationhierarchy", mh, randPrefix+"-"+testingMigrationHierarchyLabel+"=true")
 }
 
+// labelTestingGroups marks testing groups with a label for future search and lookup.
+func labelTestingGroup(group, randPrefix string) {
+	MustRun("kubectl label --overwrite group", group, randPrefix+"-"+testingGroupLabel+"=true")
+}
+
 // labelTestingUsers marks testing users with a label for future search and lookup.
 func labelTestingUsers(user, randPrefix string) {
 	MustRun("kubectl label --overwrite user", user, randPrefix+"-"+testingUserLabel+"=true")
@@ -272,6 +278,18 @@ func CleanupTestUsers(randPrefix string) {
 		return nil
 	}).Should(Succeed(), "while getting list of users to clean up")
 	cleanupUsers(users...)
+}
+
+// CleanupTestGroups deletes a specific group
+func CleanupTestGroup(groupName string) {
+	EventuallyWithOffset(1, func() error {
+		_, err := RunCommand("kubectl get groups -o custom-columns=:.metadata.name --no-headers=true ", groupName)
+		if err != nil {
+			return err
+		}
+		return nil
+	}).Should(Succeed(), "while getting list of users to clean up")
+	cleanupGroup(groupName)
 }
 
 // reverseSlice takes a slice and returns it in reverse order
@@ -340,6 +358,12 @@ func cleanupUsers(users ...string) {
 	}
 }
 
+// cleanupGroups does everything it can to delete the passed-in namespaces
+func cleanupGroup(group string) {
+
+	err := TryRun("kubectl delete user", group)
+	Expect(err).Should(BeNil())
+}
 func writeTempFile(cxt string) string {
 	f, err := os.CreateTemp(os.TempDir(), "e2e-test-*.yaml")
 	Expect(err).Should(BeNil())


### PR DESCRIPTION
This PR introduces a configmap containing a list of comma delimeted "permitted groups" in config/manager/kustomization.yaml.

Users in these groups will automatically be able to create an updateQuota or migrationHierarchy, Even if they are not admins in the relevant namespaces. Also added test cases for this behavior.