### PR TITLE
Hotfix for UpdateQuoata tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
-	k8s.io/client-go v0.29.2
+	k8s.io/client-go v0.29.3
 	sigs.k8s.io/controller-runtime v0.17.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ k8s.io/apiextensions-apiserver v0.29.0 h1:0VuspFG7Hj+SxyF/Z/2T0uFbI5gb5LRgEyUVE3
 k8s.io/apiextensions-apiserver v0.29.0/go.mod h1:TKmpy3bTS0mr9pylH0nOt/QzQRrW7/h7yLdRForMZwc=
 k8s.io/apimachinery v0.29.3 h1:2tbx+5L7RNvqJjn7RIuIKu9XTsIZ9Z5wX2G22XAa5EU=
 k8s.io/apimachinery v0.29.3/go.mod h1:hx/S4V2PNW4OMg3WizRrHutyB5la0iCUbZym+W0EQIU=
-k8s.io/client-go v0.29.2 h1:FEg85el1TeZp+/vYJM7hkDlSTFZ+c5nnK44DJ4FyoRg=
-k8s.io/client-go v0.29.2/go.mod h1:knlvFZE58VpqbQpJNbCbctTVXcd35mMyAAwBdpt4jrA=
+k8s.io/client-go v0.29.3 h1:R/zaZbEAxqComZ9FHeQwOh3Y1ZUs7FaHKZdQtIc2WZg=
+k8s.io/client-go v0.29.3/go.mod h1:tkDisCvgPfiRpxGnOORfkljmS+UrW+WtXAy2fTvXJB0=
 k8s.io/component-base v0.29.0 h1:T7rjd5wvLnPBV1vC4zWd/iWRbV8Mdxs+nGaoaFzGw3s=
 k8s.io/component-base v0.29.0/go.mod h1:sADonFTQ9Zc9yFLghpDpmNXEdHyQmFIGbiuZbqAXQ1M=
 k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=

--- a/test/e2e_tests/migrationhierarchy_test.go
+++ b/test/e2e_tests/migrationhierarchy_test.go
@@ -16,7 +16,6 @@ var _ = Describe("MigrationHierarchy", func() {
 
 		CleanupTestNamespaces(randPrefix)
 		CleanupTestMigrationHierarchies(randPrefix)
-		CleanupTestGroup("test")
 
 		nsRoot = GenerateE2EName("root", testPrefix, randPrefix)
 		CreateRootNS(nsRoot, randPrefix, rqDepth)
@@ -26,7 +25,6 @@ var _ = Describe("MigrationHierarchy", func() {
 	AfterEach(func() {
 		CleanupTestNamespaces(randPrefix)
 		CleanupTestMigrationHierarchies(randPrefix)
-		CleanupTestGroup("test")
 
 	})
 

--- a/test/e2e_tests/updatequota_test.go
+++ b/test/e2e_tests/updatequota_test.go
@@ -15,7 +15,6 @@ var _ = Describe("UpdateQuota", func() {
 
 		CleanupTestNamespaces(randPrefix)
 		CleanupTestUsers(randPrefix)
-		CleanupTestGroup("test")
 
 		nsRoot = GenerateE2EName("root", testPrefix, randPrefix)
 		CreateRootNS(nsRoot, randPrefix, rqDepth)
@@ -25,7 +24,6 @@ var _ = Describe("UpdateQuota", func() {
 	AfterEach(func() {
 		CleanupTestNamespaces(randPrefix)
 		CleanupTestUsers(randPrefix)
-		CleanupTestGroup("test")
 
 	})
 
@@ -238,6 +236,7 @@ var _ = Describe("UpdateQuota", func() {
 		CreateUpdateQuota("updatequota-from-"+nsA+"-to-"+nsB, nsA, nsB, userA, "pods", "10")
 
 		FieldShouldContain("subnamespace", nsRoot, nsB, ".status.total.free.pods", "35")
+		CleanupTestGroup("test")
 
 	})
 })


### PR DESCRIPTION
This PR fixes an issue where sometimes the updatequota group test would fail because another test deleted the group before it could be labeled. 
Bumped versions for k8s.io/client-go