### PR TITLE
feat: move limitRange default values to an external configmap.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.60.3
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/api/v1/subnamespace_types.go
+++ b/api/v1/subnamespace_types.go
@@ -74,6 +74,7 @@ type SubnamespaceStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=sns
 
 // Subnamespace is the Schema for the subnamespaces API
 type Subnamespace struct {

--- a/config/crd/bases/dana.hns.io_subnamespaces.yaml
+++ b/config/crd/bases/dana.hns.io_subnamespaces.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Subnamespace
     listKind: SubnamespaceList
     plural: subnamespaces
+    shortNames:
+    - sns
     singular: subnamespace
   scope: Namespaced
   versions:
@@ -97,11 +99,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - operator
                           - scopeName
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                     x-kubernetes-map-type: atomic
                   scopes:
@@ -113,6 +117,7 @@ spec:
                         match each object tracked by a quota
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
             type: object
           status:
@@ -174,11 +179,13 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - operator
                                 - scopeName
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                           x-kubernetes-map-type: atomic
                         scopes:
@@ -190,6 +197,7 @@ spec:
                               must match each object tracked by a quota
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                   type: object
                 type: array

--- a/config/crd/bases/dana.hns.io_updatequotas.yaml
+++ b/config/crd/bases/dana.hns.io_updatequotas.yaml
@@ -91,11 +91,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - operator
                           - scopeName
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                     x-kubernetes-map-type: atomic
                   scopes:
@@ -107,6 +109,7 @@ spec:
                         match each object tracked by a quota
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               sourcens:
                 description: SourceNamespace is name of the Subnamespace from which

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,3 +10,8 @@ configMapGenerator:
 - literals:
   - PERMITTED_GROUPS='test'
   name: permitted-groups-cm
+- files:
+  - limitRangeDefaults
+  name: config
+  options:
+    disableNameSuffixHash: true

--- a/config/manager/limitRangeDefaults
+++ b/config/manager/limitRangeDefaults
@@ -1,0 +1,13 @@
+minimum:
+   memory: 50Mi
+   cpu: 25m
+defaultRequest:
+   memory: 100Mi
+   cpu: 50m
+defaultLimit:
+   memory: 300Mi
+   cpu: 150m
+maximum:
+   cpu: 128
+minimumPVC:
+  storage: 20Mi

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - limitranges
   verbs:
   - create

--- a/config/webhook-dev/manifests.yaml
+++ b/config/webhook-dev/manifests.yaml
@@ -138,7 +138,9 @@ webhooks:
       - operations:
           - CREATE
           - UPDATE
-          - DELETE
+#          Since only the sns service account is allowed to delete subnamespaces and when running with make dev, the dana account is used,
+#          We skip the delete validations when running locally
+#          - DELETE
         apiGroups:
           - dana.hns.io
         apiVersions:

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -24,8 +24,8 @@ func IndexOf(element string, a []string) (int, error) {
 }
 
 // ContainsString checks if a string is present in a slice of strings.
-func ContainsString(sslice []string, s string) bool {
-	for _, a := range sslice {
+func ContainsString(slice []string, s string) bool {
+	for _, a := range slice {
 		if a == s {
 			return true
 		}

--- a/internal/migrationhierarchy/controller.go
+++ b/internal/migrationhierarchy/controller.go
@@ -311,7 +311,7 @@ func (r *MigrationHierarchyReconciler) createSNS(sns *objectcontext.ObjectContex
 	}
 
 	if err := newSNS.EnsureCreate(); err != nil {
-		return newSNS, fmt.Errorf("creating the subnamespace under the destination namespace failed because: " + err.Error())
+		return newSNS, fmt.Errorf("creating the subnamespace under the destination namespace failed: %w", err)
 	}
 
 	return newSNS, nil
@@ -333,7 +333,7 @@ func ComposeSNS(name string, namespace string, quota corev1.ResourceList, labels
 // deleteSNS deletes a subnamespace
 func (r *MigrationHierarchyReconciler) deleteSNS(sns *objectcontext.ObjectContext) error {
 	if err := sns.EnsureDelete(); err != nil {
-		return fmt.Errorf("deleting the subnamespace failed because: " + err.Error())
+		return fmt.Errorf("deleting the subnamespace failed: %w", err)
 	}
 
 	return nil

--- a/internal/quota/configmap.go
+++ b/internal/quota/configmap.go
@@ -1,0 +1,55 @@
+package quota
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ConfigMapData struct {
+	Minimum        resourceQuantities `json:"minimum" yaml:"minimum"`
+	DefaultRequest resourceQuantities `json:"defaultRequest" yaml:"defaultRequest"`
+	DefaultLimit   resourceQuantities `json:"defaultLimit" yaml:"defaultLimit"`
+	Maximum        resourceQuantities `json:"maximum" yaml:"maximum"`
+	MinimumPVC     resourceQuantities `json:"minimumPVC" yaml:"minimumPVC"`
+}
+
+type resourceQuantities struct {
+	Memory  resource.Quantity `json:"memory,omitempty" yaml:"memory,omitempty"`
+	CPU     resource.Quantity `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	Storage resource.Quantity `json:"storage,omitempty" yaml:"storage,omitempty"`
+}
+
+const (
+	namespaceName = "sns-system"
+	configMapName = "sns-config"
+)
+
+// getConfigMapData retrieves the ConfigMap data from the cluster.
+func getConfigMapData(ctx context.Context, k8sClient client.Client, key string) (string, error) {
+	cm := &corev1.ConfigMap{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespaceName}, cm)
+	if err != nil {
+		return "", err
+	}
+	marshalledData, ok := cm.Data[key]
+	if !ok {
+		return "", fmt.Errorf("configmap %q does not contain key %s", configMapName, limitConfigMapKey)
+	}
+
+	return marshalledData, nil
+}
+
+// parseLimitRangeData parses the data from the ConfigMap into a ConfigMapData struct.
+func parseLimitRangeData(data string) (ConfigMapData, error) {
+	limitRangeData := ConfigMapData{}
+	if err := yaml.Unmarshal([]byte(data), &limitRangeData); err != nil {
+		return ConfigMapData{}, fmt.Errorf("failed parsing limit range data: %w", err)
+	}
+	return limitRangeData, nil
+}

--- a/internal/quota/limitrange.go
+++ b/internal/quota/limitrange.go
@@ -1,30 +1,44 @@
 package quota
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/dana-team/hns/internal/objectcontext"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	minPodCpu    = resource.MustParse("25m")
-	minPodMem    = resource.MustParse("50Mi")
-	minContainer = corev1.ResourceList{"cpu": minPodCpu, "memory": minPodMem}
+const limitConfigMapKey = "limitRangeDefaults"
 
-	defaultRequestPodCpu = resource.MustParse("50m")
-	defaultRequestPodMem = resource.MustParse("100Mi")
-	defaultRequest       = corev1.ResourceList{"cpu": defaultRequestPodCpu, "memory": defaultRequestPodMem}
+// getLimits returns the limits that are set in the limitRange.yaml field in the sns-config configmap.
+func getLimits(ctx context.Context, k8sClient client.Client) ([]corev1.LimitRangeItem, error) {
+	limitRangeData, err := getConfigMapData(ctx, k8sClient, limitConfigMapKey)
+	if err != nil {
+		return nil, err
+	}
+	parsedLimits, err := parseLimitRangeData(limitRangeData)
+	if err != nil {
+		return nil, err
+	}
+	minPodCpu := parsedLimits.Minimum.CPU
+	minPodMem := parsedLimits.Minimum.Memory
+	minContainer := corev1.ResourceList{"cpu": minPodCpu, "memory": minPodMem}
 
-	defaultLimitPodCpu = resource.MustParse("150m")
-	defaultLimitPodMem = resource.MustParse("300Mi")
-	defaultLimit       = corev1.ResourceList{"cpu": defaultLimitPodCpu, "memory": defaultLimitPodMem}
+	defaultRequestPodCpu := parsedLimits.DefaultRequest.CPU
+	defaultRequestPodMem := parsedLimits.DefaultRequest.Memory
+	defaultRequest := corev1.ResourceList{"cpu": defaultRequestPodCpu, "memory": defaultRequestPodMem}
 
-	maxRequestPodCpu = resource.MustParse("128")
-	maxRequest       = corev1.ResourceList{"cpu": maxRequestPodCpu}
+	defaultLimitPodCpu := parsedLimits.DefaultLimit.CPU
+	defaultLimitPodMem := parsedLimits.DefaultLimit.Memory
+	defaultLimit := corev1.ResourceList{"cpu": defaultLimitPodCpu, "memory": defaultLimitPodMem}
 
-	ContainerLimits = corev1.LimitRangeItem{
+	maxRequestPodCpu := parsedLimits.Maximum.CPU
+	maxRequest := corev1.ResourceList{"cpu": maxRequestPodCpu}
+
+	ContainerLimits := corev1.LimitRangeItem{
 		Type:           "Container",
 		Min:            minContainer,
 		Max:            maxRequest,
@@ -32,20 +46,26 @@ var (
 		DefaultRequest: defaultRequest,
 	}
 
-	minPVC    = corev1.ResourceList{"storage": resource.MustParse("20Mi")}
-	PVCLimits = corev1.LimitRangeItem{
+	minPVC := corev1.ResourceList{"storage": parsedLimits.MinimumPVC.Storage}
+	PVCLimits := corev1.LimitRangeItem{
 		Type: "PersistentVolumeClaim",
 		Min:  minPVC,
 	}
 
-	Limits = []corev1.LimitRangeItem{ContainerLimits, PVCLimits}
-)
+	return []corev1.LimitRangeItem{ContainerLimits, PVCLimits}, nil
+}
 
 // CreateDefaultSNSLimitRange creates a limit range object with some default values
 // that we would like to limit and are not set by the user.
 func CreateDefaultSNSLimitRange(snsObject *objectcontext.ObjectContext) error {
 	snsName := snsObject.Name()
-	composedDefaultLimitRange := composeLimitRange(snsName, snsName, Limits)
+
+	limits, err := getLimits(snsObject.Ctx, snsObject.Client)
+	if err != nil {
+		return fmt.Errorf("error getting default limits: %w", err)
+	}
+
+	composedDefaultLimitRange := composeLimitRange(snsName, snsName, limits)
 
 	childLimitRange, err := objectcontext.New(snsObject.Ctx, snsObject.Client, types.NamespacedName{Name: snsName, Namespace: snsName}, composedDefaultLimitRange)
 	if err != nil {

--- a/internal/subnamespace/controller.go
+++ b/internal/subnamespace/controller.go
@@ -36,6 +36,7 @@ type snsPhaseFunc func(*objectcontext.ObjectContext, *objectcontext.ObjectContex
 // +kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="quota.openshift.io",resources=clusterresourcequotas,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;
 
 // SetupWithManager sets up the controller by specifying the following: controller is managing the reconciliation
 // of subnamespace objects and is watching for changes to the SNSEvents channel and enqueues requests for the


### PR DESCRIPTION
With this PR, the default resource quantities for the limitranges created by the sns controller have been moved to an external configmap. This enables the changing of the default values without redeploying the controller.